### PR TITLE
scala3 support, springWithStart

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = 3.0.6
+version = 3.4.3
 maxColumn = 120
 docstrings.wrapMaxColumn = 80
 align.preset = most

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ inThisBuild(
     normalizedName := "animus",
     organization := "com.kitlangton",
     scalaVersion := "2.13.8",
-    crossScalaVersions := Seq("2.13.8"),
+    crossScalaVersions := Seq("2.13.8", "3.1.2"),
     organization := "io.github.kitlangton",
     homepage := Some(url("https://github.com/kitlangton/animus")),
     licenses := List("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
@@ -86,16 +86,24 @@ lazy val animus = crossProject(JSPlatform, JVMPlatform)
   .settings(
     commonSettings,
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
-    libraryDependencies += "dev.zio" %%% "zio-test" % "2.0.0" % Test
+    libraryDependencies += "dev.zio"         %%% "zio-test" % "2.0.0" % Test
   )
   .jsSettings(
     testFrameworks += new TestFramework("zio.test.sbt.ZTestFramework"),
     scalaJSLinkerConfig ~= { _.withSourceMap(false) },
     libraryDependencies ++= Seq(
-      "com.raquo"           %%% "laminar"       % "0.14.2",
-      "com.propensive"      %%% "magnolia"      % "0.17.0",
-      scalaOrganization.value % "scala-reflect" % scalaVersion.value
-    )
+      "com.raquo"                            %%% "laminar"  % "0.14.2"
+    ) ++ {
+      CrossVersion.partialVersion(scalaVersion.value) match {
+        case Some((3, _)) =>
+          Seq("com.softwaremill.magnolia1_3" %%% "magnolia" % "1.1.5")
+        case _ =>
+          Seq(
+            "com.propensive"                 %%% "magnolia" % "0.17.0",
+            scalaOrganization.value % "scala-reflect" % scalaVersion.value
+          )
+      }
+    }
   )
 
 lazy val animusJS  = animus.js

--- a/js/src/main/scala-2/animus/Animatable.scala
+++ b/js/src/main/scala-2/animus/Animatable.scala
@@ -1,0 +1,16 @@
+package animus
+
+trait Animatable[A] {
+
+  type Anim
+
+  def toAnim(start: A, value: A): Anim
+
+  def fromAnim(anim: Anim): A
+
+  def tick(anim: Anim, time: Double): Boolean
+
+  def update(anim: Anim, newValue: A): Unit
+}
+
+object Animatable extends AnimatableImplicits

--- a/js/src/main/scala-2/animus/DeriveAnimatable.scala
+++ b/js/src/main/scala-2/animus/DeriveAnimatable.scala
@@ -9,12 +9,12 @@ object DeriveAnimatable {
     new Animatable[T] {
       override type Anim = Array[Any]
 
-      override def toAnim(value: T): Array[Any] = {
+      override def toAnim(start: T, value: T): Array[Any] = {
         var i     = -1
         val anims = Array.ofDim[Any](ctx.parameters.length)
         ctx.parameters.foreach { param =>
           i += 1
-          anims(i) = param.typeclass.toAnim(param.dereference(value))
+          anims(i) = param.typeclass.toAnim(param.dereference(start), param.dereference(value))
         }
         anims
       }

--- a/js/src/main/scala-3/animus/Animatable.scala
+++ b/js/src/main/scala-3/animus/Animatable.scala
@@ -1,0 +1,100 @@
+package animus
+
+import magnolia1._
+
+trait Animatable[A] {
+
+  type Anim
+
+  type A0 = A
+
+  def toAnim(start: A, value: A): Anim
+
+  def fromAnim(anim: Anim): A
+
+  def tick(anim: Anim, time: Double): Boolean
+
+  def update(anim: Anim, newValue: A): Unit
+}
+
+object Animatable extends AutoDerivation[Animatable] with AnimatableImplicits {
+
+  def join[T](ctx: CaseClass[Animatable, T]): Animatable[T] =
+    new Animatable[T] {
+      override type Anim = Array[Any]
+
+      override def toAnim(start: T, value: T): Array[Any] = {
+        var i     = -1
+        val anims = Array.ofDim[Any](ctx.params.length)
+        ctx.params.foreach { param =>
+          i += 1
+          anims(i) = param.typeclass.toAnim(param.deref(start), param.deref(value))
+        }
+        anims
+      }
+
+      override def tick(anim: Array[Any], time: Double): Boolean = {
+        var i       = -1
+        var allDone = true
+        ctx.params.foreach { param =>
+          i += 1
+          val typeclass = param.typeclass
+          val paramDone = typeclass.tick(anim(i).asInstanceOf[typeclass.Anim], time)
+          allDone = allDone && paramDone
+        }
+        allDone
+      }
+
+      override def update(anim: Array[Any], newValue: T): Unit = {
+        var i = -1
+        ctx.params.foreach { param =>
+          i += 1
+          val typeclass = param.typeclass
+          typeclass.update(anim(i).asInstanceOf[typeclass.Anim], param.deref(newValue))
+        }
+      }
+
+      override def fromAnim(anim: Array[Any]): T = {
+        var i = -1
+        ctx.construct { param =>
+          i += 1
+          val animatable = param.typeclass
+          val value      = animatable.fromAnim(anim(i).asInstanceOf[animatable.Anim])
+          value
+        }
+      }
+
+    }
+
+  override def split[T](ctx: SealedTrait[Animatable, T]): Animatable[T] =
+    new Animatable[T] {
+      override type Anim = Array[Any]
+
+      /* TODO: assumes toAnim is always called before tick, update, and fromAnim or
+       *  won't work by saving the value and using it to multiplex!  Is this OK? */
+      var valueOpt: Option[T] = None
+
+      override def toAnim(start: T, value: T): Array[Any] = {
+        valueOpt = Some(value)
+        ctx.choose(value)(sub => sub.typeclass.toAnim(sub.cast(start), sub.cast(value)).asInstanceOf[Anim])
+      }
+
+      override def tick(anim: Array[Any], time: Double): Boolean =
+        ctx.choose(valueOpt.get) { sub =>
+          val animatable = sub.typeclass
+          animatable.tick(anim.asInstanceOf[animatable.Anim], time)
+        }
+
+      override def update(anim: Array[Any], newValue: T): Unit =
+        ctx.choose(valueOpt.get) { sub =>
+          val animatable = sub.typeclass
+          animatable.update(anim.asInstanceOf[animatable.Anim], newValue.asInstanceOf[animatable.A0])
+        }
+
+      override def fromAnim(anim: Array[Any]): T =
+        ctx.choose(valueOpt.get) { sub =>
+          val animatable = sub.typeclass
+          animatable.fromAnim(anim.asInstanceOf[animatable.Anim])
+        }
+    }
+}

--- a/js/src/main/scala/animus/Spring.scala
+++ b/js/src/main/scala/animus/Spring.scala
@@ -55,6 +55,9 @@ final class Spring(
 }
 
 object Spring {
+  def fromValueAndTarget(value: Double, target: Double): Spring =
+    new Spring(position = value, to = target)
+
   def fromValue(value: Double): Spring =
     new Spring(position = value, to = value)
 

--- a/js/src/main/scala/animus/package.scala
+++ b/js/src/main/scala/animus/package.scala
@@ -7,10 +7,14 @@ package object animus {
 
   implicit final class SignalOps[A](private val self: Signal[A]) extends AnyVal {
     def px: Signal[String]                                    = self.map(x => s"${x}px")
-    def spring(implicit animatable: Animatable[A]): Signal[A] = new SpringSignal[A](self)
+    def spring(implicit animatable: Animatable[A]): Signal[A] = new SpringSignal[A](self.map((_, None)))
 
     def splitOneTransition[Key, Out](key: A => Key)(project: (Key, A, Signal[A], Transition) => Out): Signal[Seq[Out]] =
       Transitions.transitionList(self.map(List(_)))(key)(project)
+  }
+
+  implicit final class SignalWithStartOps[A](private val self: Signal[(A, Option[A])]) extends AnyVal {
+    def springWithStart(implicit animatable: Animatable[A]): Signal[A] = new SpringSignal[A](self)
   }
 
   implicit final class SignalSeqOps[A](private val self: Signal[Seq[A]]) extends AnyVal {


### PR DESCRIPTION
scala3 required a move to magnolia1 which is backward incompatible.  In magnolia1 we need Animatable's companion object to extend the new AutoDerivation trait and since the companion must be in the same file we put the file in js/src/main/scala-3 and the original Animatable and DeriveAnimatable in js/src/main/scala-2.

springWithStart is an addition to the API that allows the signal to pass an optional initial position to Spring.  It operates on a Signal[(A, Option[A])] where A is Animatable.  This is useful, for example, when an element must change parents.  Changing parents is not currently possible in Laminar so a new element must be created and this call allows the new element to visually originate from the prior element's position.  It's useful for other cases where we need to specify an initial position, but this position isn't known until the transaction that creates the element.